### PR TITLE
docs(readme): add troubleshooting entry for invalid ca certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,8 @@ If you're running this add-on outside of the official gateway image for the Rasp
 ```
 sudo pip3 install git+https://github.com/WebThingsIO/gateway-addon-python.git
 ```
+
+# Troubleshooting
+
+* When no speedtest is executed and the gauge stays at `0`, the CA certificates may need to be refreshed.
+  * On the system running the gateway execute: `# update-ca-certificates --fresh`


### PR DESCRIPTION
Add troubleshooting in readme and explain how to update ca certificates.